### PR TITLE
Potential fix for code scanning alert no. 1: Incorrect conversion between integer types

### DIFF
--- a/cmd/agent/scrapers/factorio/factorio.go
+++ b/cmd/agent/scrapers/factorio/factorio.go
@@ -63,7 +63,7 @@ func (s Scraper) Scrape(ctx context.Context, logger *zap.Logger) (model.GameServ
 	var maxPlayers uint64
 	maxPlayers, err = strconv.ParseUint(strings.TrimSpace(response.Body), 10, 32)
 	if err != nil {
-		logger.Error("Could not parse max player count")
+		logger.Error("Could not parse max player count", zap.Error(err), zap.String("responseBody", response.Body))
 		return model.GameServerDynamicData{}, err
 	}
 

--- a/cmd/agent/scrapers/factorio/factorio.go
+++ b/cmd/agent/scrapers/factorio/factorio.go
@@ -60,8 +60,8 @@ func (s Scraper) Scrape(ctx context.Context, logger *zap.Logger) (model.GameServ
 		return model.GameServerDynamicData{}, err
 	}
 
-	var maxPlayers int
-	maxPlayers, err = strconv.Atoi(strings.TrimSpace(response.Body))
+	var maxPlayers uint64
+	maxPlayers, err = strconv.ParseUint(strings.TrimSpace(response.Body), 10, 32)
 	if err != nil {
 		logger.Error("Could not parse max player count")
 		return model.GameServerDynamicData{}, err


### PR DESCRIPTION
Potential fix for [https://github.com/Ctrl-Alt-GG/projectile/security/code-scanning/1](https://github.com/Ctrl-Alt-GG/projectile/security/code-scanning/1)

Use `strconv.ParseUint(..., 10, 32)` instead of `strconv.Atoi` for `maxPlayers`, then cast the parsed `uint64` to `uint32`. This avoids architecture-dependent `int` and guarantees the parsed value fits into 32 bits before conversion.

In `cmd/agent/scrapers/factorio/factorio.go`, update the block around lines 63–68:
- Change `maxPlayers` type from `int` to `uint64`.
- Replace `strconv.Atoi(...)` with `strconv.ParseUint(..., 10, 32)`.

No new imports are needed (`strconv` and `strings` are already present). This preserves functionality while making overflow/truncation impossible at the conversion point.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
